### PR TITLE
Fix vocabulary menu keys

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,13 +62,13 @@ def main():
     kanaTags.sort()
 
     vocabMenuFunctions = {
-        "All": {"function": guessCards, "args": [vocabCardDeck, "japanese", "english"]},
-        "By Category": {"function": customGuessCards, "args": [vocabCardDeck, vocabTags, "japanese", "english"]},
+        "All": {"function": guessCards, "args": [vocabCardDeck, "kana", "english"]},
+        "By Category": {"function": customGuessCards, "args": [vocabCardDeck, vocabTags, "kana", "english"]},
     }
 
     vocabFunctions = {
         "Vocabulary": {"function": menu, "args": ["Japanese (日本語) Vocabulary", "", vocabMenuFunctions]},
-        "Pronunciation": {"function": guessCards, "args": [vocabCardDeck, "japanese", "pronunciation"]}
+        "Pronunciation": {"function": guessCards, "args": [vocabCardDeck, "kana", "romaji"]}
     }
 
     mainMenuFunctions = {


### PR DESCRIPTION
## Summary
- fix wrong column names used for vocab menus

## Testing
- `python3 -m py_compile main.py flashCards.py games.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6845c0306b34832a9a4cd24bff30ef01