### PR TITLE
Add desktop GUI mode for flashcard practice

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,153 @@
+import random
+import tkinter as tk
+from tkinter import ttk
+
+from flashCards import FlashCardDeck
+
+KANA_CSV = "kana.csv"
+JAP_VOCAB_CSV = "jap-vocab.csv"
+
+
+class FlashcardsGUI:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("Kana Flashcards")
+        self.root.geometry("680x420")
+
+        self.decks = {
+            "Kana": FlashCardDeck(KANA_CSV),
+            "Vocabulary": FlashCardDeck(JAP_VOCAB_CSV),
+        }
+
+        self.deck_var = tk.StringVar(value="Kana")
+        self.show_side_var = tk.StringVar(value="hiragana")
+        self.answer_side_var = tk.StringVar(value="romaji")
+
+        self.session_cards = []
+        self.current_card = None
+        self.total_answered = 0
+        self.correct_answers = 0
+
+        self._build_ui()
+        self._sync_side_options()
+
+    def _build_ui(self):
+        controls = ttk.LabelFrame(self.root, text="Session Settings", padding=12)
+        controls.pack(fill="x", padx=12, pady=(12, 6))
+
+        ttk.Label(controls, text="Deck").grid(row=0, column=0, sticky="w")
+        deck_combo = ttk.Combobox(
+            controls,
+            textvariable=self.deck_var,
+            values=list(self.decks.keys()),
+            width=14,
+            state="readonly",
+        )
+        deck_combo.grid(row=0, column=1, padx=(8, 16), sticky="w")
+        deck_combo.bind("<<ComboboxSelected>>", lambda _event: self._sync_side_options())
+
+        ttk.Label(controls, text="Show Side").grid(row=0, column=2, sticky="w")
+        self.show_side_combo = ttk.Combobox(controls, textvariable=self.show_side_var, width=16, state="readonly")
+        self.show_side_combo.grid(row=0, column=3, padx=(8, 16), sticky="w")
+
+        ttk.Label(controls, text="Answer Side").grid(row=0, column=4, sticky="w")
+        self.answer_side_combo = ttk.Combobox(
+            controls,
+            textvariable=self.answer_side_var,
+            width=16,
+            state="readonly",
+        )
+        self.answer_side_combo.grid(row=0, column=5, padx=(8, 0), sticky="w")
+
+        ttk.Button(controls, text="Start Session", command=self.start_session).grid(
+            row=0, column=6, padx=(16, 0), sticky="e"
+        )
+
+        card_frame = ttk.LabelFrame(self.root, text="Card", padding=12)
+        card_frame.pack(fill="both", expand=True, padx=12, pady=6)
+
+        self.prompt_label = ttk.Label(card_frame, text="Click 'Start Session' to begin.", font=("Arial", 18))
+        self.prompt_label.pack(pady=(24, 16))
+
+        answer_row = ttk.Frame(card_frame)
+        answer_row.pack()
+
+        ttk.Label(answer_row, text="Your Answer:").pack(side="left")
+        self.answer_entry = ttk.Entry(answer_row, width=30)
+        self.answer_entry.pack(side="left", padx=(8, 8))
+        self.answer_entry.bind("<Return>", lambda _event: self.submit_answer())
+
+        ttk.Button(answer_row, text="Submit", command=self.submit_answer).pack(side="left")
+        ttk.Button(answer_row, text="Next Card", command=self.next_card).pack(side="left", padx=(8, 0))
+
+        self.feedback_label = ttk.Label(card_frame, text="", font=("Arial", 12))
+        self.feedback_label.pack(pady=(14, 4))
+
+        self.score_label = ttk.Label(card_frame, text="Score: 0/0")
+        self.score_label.pack()
+
+    def _sync_side_options(self):
+        deck = self.decks[self.deck_var.get()]
+        options = [key for key in deck.cards[0].sides.keys() if key != "tags"]
+
+        self.show_side_combo["values"] = options
+        self.answer_side_combo["values"] = options
+
+        if self.show_side_var.get() not in options:
+            self.show_side_var.set(options[0])
+        if self.answer_side_var.get() not in options:
+            self.answer_side_var.set(options[min(1, len(options)-1)])
+
+    def start_session(self):
+        deck = self.decks[self.deck_var.get()]
+        self.session_cards = [card for card in deck.cards if self._card_is_usable(card)]
+        random.shuffle(self.session_cards)
+
+        self.total_answered = 0
+        self.correct_answers = 0
+        self.score_label.config(text="Score: 0/0")
+        self.feedback_label.config(text="")
+        self.next_card()
+
+    def _card_is_usable(self, card):
+        shown = card.sides.get(self.show_side_var.get(), "n/a")
+        answer = card.sides.get(self.answer_side_var.get(), "n/a")
+        return shown != "n/a" and answer != "n/a"
+
+    def next_card(self):
+        self.answer_entry.delete(0, tk.END)
+        self.feedback_label.config(text="")
+
+        if not self.session_cards:
+            self.current_card = None
+            self.prompt_label.config(text="Session complete! Click 'Start Session' to play again.")
+            return
+
+        self.current_card = self.session_cards.pop()
+        show_key = self.show_side_var.get()
+        self.prompt_label.config(text=self.current_card.sides[show_key])
+        self.answer_entry.focus_set()
+
+    def submit_answer(self):
+        if self.current_card is None:
+            self.feedback_label.config(text="No active card. Start a session first.")
+            return
+
+        guess = self.answer_entry.get().strip()
+        answer_key = self.answer_side_var.get()
+        expected = self.current_card.sides[answer_key]
+
+        self.total_answered += 1
+        if guess == expected:
+            self.correct_answers += 1
+            self.feedback_label.config(text="✅ Correct!")
+        else:
+            self.feedback_label.config(text=f"❌ Incorrect. Answer: {expected}")
+
+        self.score_label.config(text=f"Score: {self.correct_answers}/{self.total_answered}")
+
+
+def run_gui():
+    root = tk.Tk()
+    FlashcardsGUI(root)
+    root.mainloop()

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 #!/mingw64/bin/python3
 
-from flashCards import FlashCardDeck
-from utils import createMenu as menu
-from utils import getUserInput
-from games import guessCards, customGuessCards
+import argparse
 import os
+
+from flashCards import FlashCardDeck
+from gui import run_gui
 
 KANA_CSV = "kana.csv"
 KANA_TEST_CSV = "kana-test.csv"
@@ -12,6 +12,10 @@ JAP_VOCAB_CSV = "jap-vocab.csv"
 
 
 def kanaPracticeMenu(kanaCardDeck, kanas):
+    from utils import createMenu as menu
+    from utils import getUserInput
+    from games import guessCards, customGuessCards
+
     shownKana = getUserInput(
         "Enter what kana type you want shown:\n  - Romaji\n  - Hiragana\n  - Katakana\n", ['r', 'h', 'k'])[0].lower()
     os.system('cls')
@@ -24,11 +28,14 @@ def kanaPracticeMenu(kanaCardDeck, kanas):
         "Custom": {"function": customGuessCards, "args": [kanaCardDeck, kanas, key[shownKana], key[guessKana]]},
     }
 
-    menu(f"{key[shownKana].capitalize()} ⟶   {key[guessKana].capitalize()}",
-         "", kanaMenuFunctions)
+    menu(f"{key[shownKana].capitalize()} ⟶   {key[guessKana].capitalize()}", "", kanaMenuFunctions)
 
 
 def vocabPracticeMenu(vocabCardDeck, vocabTags):
+    from utils import createMenu as menu
+    from utils import getUserInput
+    from games import guessCards, customGuessCards
+
     shownSide = getUserInput(
         "Enter what you want shown:\n  - English\n  - Romaji\n  - Kana (no Kanji)\n  - Kana (with Kanji)\n", ['english', 'romaji', 'kana', 'kanji']).lower()
     os.system('cls')
@@ -40,12 +47,13 @@ def vocabPracticeMenu(vocabCardDeck, vocabTags):
         "Custom": {"function": customGuessCards, "args": [vocabCardDeck, vocabTags, shownSide, guessSide]},
     }
 
-    menu(f"{shownSide.capitalize()} ⟶   {guessSide.capitalize()}",
-         "", vocabMenuFunctions)
+    menu(f"{shownSide.capitalize()} ⟶   {guessSide.capitalize()}", "", vocabMenuFunctions)
 
 
 def main():
-    # kanaCardDeck = FlashCardDeck(KANA_CSV)
+    from utils import createMenu as menu
+    from games import guessCards, customGuessCards
+
     kanaCardDeck = FlashCardDeck(KANA_CSV)
     vocabCardDeck = FlashCardDeck(JAP_VOCAB_CSV)
     vocabTags = []
@@ -81,4 +89,11 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Japanese flashcards")
+    parser.add_argument("--gui", action="store_true", help="Launch the desktop GUI")
+    args = parser.parse_args()
+
+    if args.gui:
+        run_gui()
+    else:
+        main()

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,7 @@
 from unicodedata import east_asian_width as eaw
-from consolemenu import ConsoleMenu
-from consolemenu.items import FunctionItem
-
-
 def createMenu(title, subtitle, functions):
+    from consolemenu import ConsoleMenu
+    from consolemenu.items import FunctionItem
 
     # Create the menu
     menu = ConsoleMenu(str(title), str(subtitle))


### PR DESCRIPTION
### Motivation
- Provide a simple desktop interface for practicing flashcards in addition to the existing CLI so users can choose a GUI mode for interactive sessions.
- Make the application resilient when CLI-only dependency `consolemenu` is not installed so the help/GUI paths do not fail.

### Description
- Added a new `gui.py` module implementing a Tkinter-based flashcard UI with deck selection, show/answer side dropdowns, session start, answer submission, next-card flow, immediate feedback, and running score tracking.
- Updated `main.py` to add a `--gui` flag that launches the GUI via `run_gui()` while preserving the original CLI menu as the default path, and moved CLI-only imports into the CLI functions to avoid import-time dependency failures.
- Refactored `utils.py` to import `consolemenu` lazily inside `createMenu()` so the module can be imported even when `consolemenu` is not installed.

### Testing
- Ran the unit test `python -m unittest -v tests/test_flashcards.py` which passed (`ok`).
- Compiled the main modules with `python -m py_compile main.py gui.py flashCards.py games.py utils.py` which succeeded without syntax errors.
- Verified `python main.py --help` runs and prints the new `--gui` option successfully.
- Verified `import gui` works by running `python - <<'PY'\nimport gui\nprint('gui import ok')\nPY` which printed `gui import ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19389739c832ab7c69d94175bc7f9)