### PR TITLE
Improve session state handling and add UI controls for flashcards GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -12,7 +12,7 @@ class FlashcardsGUI:
     def __init__(self, root):
         self.root = root
         self.root.title("Kana Flashcards")
-        self.root.geometry("680x420")
+        self.root.geometry("900x420")
 
         self.decks = {
             "Kana": FlashCardDeck(KANA_CSV),
@@ -27,6 +27,9 @@ class FlashcardsGUI:
         self.current_card = None
         self.total_answered = 0
         self.correct_answers = 0
+        self.session_active = False
+        self.card_submitted = False
+        self.last_expected_answer = ""
 
         self._build_ui()
         self._sync_side_options()
@@ -59,9 +62,13 @@ class FlashcardsGUI:
         )
         self.answer_side_combo.grid(row=0, column=5, padx=(8, 0), sticky="w")
 
-        ttk.Button(controls, text="Start Session", command=self.start_session).grid(
+        self.start_button = ttk.Button(controls, text="Start Session", command=self.start_session)
+        self.start_button.grid(
             row=0, column=6, padx=(16, 0), sticky="e"
         )
+
+        self.quit_button = ttk.Button(controls, text="Quit Session", command=self.quit_session, state="disabled")
+        self.quit_button.grid(row=0, column=7, padx=(8, 0), sticky="e")
 
         card_frame = ttk.LabelFrame(self.root, text="Card", padding=12)
         card_frame.pack(fill="both", expand=True, padx=12, pady=6)
@@ -77,7 +84,17 @@ class FlashcardsGUI:
         self.answer_entry.pack(side="left", padx=(8, 8))
         self.answer_entry.bind("<Return>", lambda _event: self.submit_answer())
 
-        ttk.Button(answer_row, text="Submit", command=self.submit_answer).pack(side="left")
+        self.submit_button = ttk.Button(answer_row, text="Submit", command=self.submit_answer)
+        self.submit_button.pack(side="left")
+
+        self.show_answer_button = ttk.Button(
+            answer_row,
+            text="Show Answer",
+            command=self.show_answer,
+            state="disabled",
+        )
+        self.show_answer_button.pack(side="left", padx=(8, 0))
+
         ttk.Button(answer_row, text="Next Card", command=self.next_card).pack(side="left", padx=(8, 0))
 
         self.feedback_label = ttk.Label(card_frame, text="", font=("Arial", 12))
@@ -98,16 +115,50 @@ class FlashcardsGUI:
         if self.answer_side_var.get() not in options:
             self.answer_side_var.set(options[min(1, len(options)-1)])
 
+    def _apply_ui_state(self, state):
+        if state == "idle":
+            self.start_button.config(state="normal")
+            self.quit_button.config(state="disabled")
+            self.submit_button.config(state="normal")
+            self.show_answer_button.config(state="disabled")
+        elif state == "in_session":
+            self.start_button.config(state="disabled")
+            self.quit_button.config(state="normal")
+            self.submit_button.config(state="normal")
+            self.show_answer_button.config(state="disabled")
+        elif state == "card_submitted_correct":
+            self.submit_button.config(state="disabled")
+            self.show_answer_button.config(state="disabled")
+        elif state == "card_submitted_incorrect":
+            self.submit_button.config(state="disabled")
+            self.show_answer_button.config(state="normal")
+
     def start_session(self):
+        if self.session_active:
+            return
+
         deck = self.decks[self.deck_var.get()]
         self.session_cards = [card for card in deck.cards if self._card_is_usable(card)]
         random.shuffle(self.session_cards)
 
         self.total_answered = 0
         self.correct_answers = 0
+        self.session_active = True
         self.score_label.config(text="Score: 0/0")
         self.feedback_label.config(text="")
+        self._apply_ui_state("in_session")
         self.next_card()
+
+    def quit_session(self):
+        self.session_active = False
+        self.session_cards = []
+        self.current_card = None
+        self.card_submitted = False
+        self.last_expected_answer = ""
+        self.answer_entry.delete(0, tk.END)
+        self.prompt_label.config(text="Click 'Start Session' to begin.")
+        self.feedback_label.config(text="")
+        self._apply_ui_state("idle")
 
     def _card_is_usable(self, card):
         shown = card.sides.get(self.show_side_var.get(), "n/a")
@@ -115,12 +166,21 @@ class FlashcardsGUI:
         return shown != "n/a" and answer != "n/a"
 
     def next_card(self):
+        if not self.session_active:
+            self.feedback_label.config(text="No active session. Click 'Start Session' to begin.")
+            return
+
         self.answer_entry.delete(0, tk.END)
         self.feedback_label.config(text="")
+        self.card_submitted = False
+        self.last_expected_answer = ""
+        self._apply_ui_state("in_session")
 
         if not self.session_cards:
             self.current_card = None
+            self.session_active = False
             self.prompt_label.config(text="Session complete! Click 'Start Session' to play again.")
+            self._apply_ui_state("idle")
             return
 
         self.current_card = self.session_cards.pop()
@@ -133,18 +193,33 @@ class FlashcardsGUI:
             self.feedback_label.config(text="No active card. Start a session first.")
             return
 
+        if self.card_submitted:
+            self.feedback_label.config(text="Answer already submitted. Click 'Next Card'.")
+            return
+
         guess = self.answer_entry.get().strip()
         answer_key = self.answer_side_var.get()
         expected = self.current_card.sides[answer_key]
+        self.last_expected_answer = expected
 
         self.total_answered += 1
         if guess == expected:
             self.correct_answers += 1
             self.feedback_label.config(text="✅ Correct!")
+            self._apply_ui_state("card_submitted_correct")
         else:
-            self.feedback_label.config(text=f"❌ Incorrect. Answer: {expected}")
+            self.feedback_label.config(text="❌ Incorrect. Click 'Show Answer' to reveal it.")
+            self._apply_ui_state("card_submitted_incorrect")
 
+        self.card_submitted = True
         self.score_label.config(text=f"Score: {self.correct_answers}/{self.total_answered}")
+
+    def show_answer(self):
+        if not self.card_submitted or not self.last_expected_answer:
+            return
+
+        self.feedback_label.config(text=f"❌ Incorrect. Answer: {self.last_expected_answer}")
+        self.show_answer_button.config(state="disabled")
 
 
 def run_gui():


### PR DESCRIPTION
### Motivation
- Prevent duplicate submissions and provide clearer session control and feedback when practicing flashcards.  
- Allow users to quit a session, reveal an answer for incorrect guesses, and avoid accidental input during state transitions.  
- Make the UI more usable by increasing window width to better accommodate controls and text.  

### Description
- Increased window size from `680x420` to `900x420` and added a `Quit Session` button next to `Start Session`.  
- Introduced session state variables `session_active`, `card_submitted`, and `last_expected_answer` and added `_apply_ui_state` to enable/disable UI controls based on state.  
- Added `quit_session` to stop a session and reset UI, updated `start_session` and `next_card` to respect `session_active` and to properly end sessions when cards exhaust.  
- Enhanced answer flow by adding a `Show Answer` button and logic in `submit_answer` to prevent double submissions, store the expected answer, update score/feedback, and reveal the answer via `show_answer` when appropriate.  

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b79ee388832abd55b0eaba91cf19)