### PR TITLE
Refactor data layer to MySQL with CSV import and RHEL setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Kana Flashcards
 
-A small Python app for practicing Japanese kana and vocabulary from CSV decks.
+A Python app for practicing Japanese kana and vocabulary.
+
+The app now reads flashcard content from **MySQL** (for both CLI and GUI). CSV files are treated as source data and imported into normalized database tables.
 
 ## Python version
 
@@ -33,6 +35,36 @@ source .venv/bin/activate
 ```bash
 pip install -r requirements.txt
 ```
+
+## MySQL setup for RHEL 8/9
+
+Use the provided setup script to optionally install MySQL (via `dnf`), ensure `mysqld` is running, create the DB/user, create schema, and import all CSV files in the repo root.
+
+```bash
+python scripts/setup_mysql_db.py --ensure-mysql --root-user root --root-password '<root_password>'
+```
+
+If MySQL is already installed/running, omit `--ensure-mysql`.
+
+### Environment variables
+
+The app and import script read these values:
+
+- `KANA_DB_HOST` (default `127.0.0.1`)
+- `KANA_DB_PORT` (default `3306`)
+- `KANA_DB_USER` (default `kana_user`)
+- `KANA_DB_PASSWORD` (default `kana_password`)
+- `KANA_DB_NAME` (default `kanaflashcards`)
+
+## Updating data from CSV
+
+To refresh database content after editing any CSV file, rerun:
+
+```bash
+python scripts/setup_mysql_db.py --root-user root --root-password '<root_password>'
+```
+
+The importer re-syncs deck content from all `*.csv` files in the specified CSV directory (default: repo root).
 
 ## Run the app
 

--- a/db.py
+++ b/db.py
@@ -1,0 +1,264 @@
+import csv
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+
+@dataclass
+class DBConfig:
+    host: str = "127.0.0.1"
+    port: int = 3306
+    user: str = "kana_user"
+    password: str = "kana_password"
+    database: str = "kanaflashcards"
+
+
+def load_db_config() -> DBConfig:
+    return DBConfig(
+        host=os.getenv("KANA_DB_HOST", "127.0.0.1"),
+        port=int(os.getenv("KANA_DB_PORT", "3306")),
+        user=os.getenv("KANA_DB_USER", "kana_user"),
+        password=os.getenv("KANA_DB_PASSWORD", "kana_password"),
+        database=os.getenv("KANA_DB_NAME", "kanaflashcards"),
+    )
+
+
+SCHEMA_SQL = [
+    """
+    CREATE TABLE IF NOT EXISTS decks (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(128) NOT NULL UNIQUE,
+        source_file VARCHAR(255) NOT NULL,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS cards (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        deck_id INT NOT NULL,
+        position INT NOT NULL,
+        UNIQUE KEY unique_deck_position (deck_id, position),
+        FOREIGN KEY (deck_id) REFERENCES decks(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS sides (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        deck_id INT NOT NULL,
+        name VARCHAR(128) NOT NULL,
+        UNIQUE KEY unique_side_name_per_deck (deck_id, name),
+        FOREIGN KEY (deck_id) REFERENCES decks(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS card_values (
+        card_id INT NOT NULL,
+        side_id INT NOT NULL,
+        value TEXT NOT NULL,
+        PRIMARY KEY (card_id, side_id),
+        FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE,
+        FOREIGN KEY (side_id) REFERENCES sides(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tags (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(128) NOT NULL UNIQUE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS card_tags (
+        card_id INT NOT NULL,
+        tag_id INT NOT NULL,
+        PRIMARY KEY (card_id, tag_id),
+        FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE,
+        FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+    )
+    """,
+]
+
+
+def parse_tags(raw: str) -> List[str]:
+    if not raw:
+        return []
+    cleaned = raw.strip()
+    if cleaned.startswith("[") and cleaned.endswith("]"):
+        cleaned = cleaned[1:-1]
+    return [token for token in cleaned.split() if token]
+
+
+class MySQLFlashcardRepository:
+    def __init__(self, config: Optional[DBConfig] = None):
+        self.config = config or load_db_config()
+
+    def connect(self, with_database: bool = True):
+        kwargs = {
+            "host": self.config.host,
+            "port": self.config.port,
+            "user": self.config.user,
+            "password": self.config.password,
+            "autocommit": False,
+        }
+        if with_database:
+            kwargs["database"] = self.config.database
+        import mysql.connector
+
+        return mysql.connector.connect(**kwargs)
+
+    def ensure_schema(self):
+        conn = self.connect(with_database=True)
+        cur = conn.cursor()
+        try:
+            for statement in SCHEMA_SQL:
+                cur.execute(statement)
+            conn.commit()
+        finally:
+            cur.close()
+            conn.close()
+
+    def list_tags(self, deck_name: str) -> List[str]:
+        conn = self.connect()
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                """
+                SELECT DISTINCT t.name
+                FROM decks d
+                JOIN cards c ON c.deck_id = d.id
+                JOIN card_tags ct ON ct.card_id = c.id
+                JOIN tags t ON t.id = ct.tag_id
+                WHERE d.name = %s
+                ORDER BY t.name
+                """,
+                (deck_name,),
+            )
+            return [row[0] for row in cur.fetchall()]
+        finally:
+            cur.close()
+            conn.close()
+
+    def load_deck(self, deck_name: str) -> List[Dict[str, str]]:
+        conn = self.connect()
+        cur = conn.cursor(dictionary=True)
+        try:
+            cur.execute("SELECT id FROM decks WHERE name=%s", (deck_name,))
+            deck_row = cur.fetchone()
+            if not deck_row:
+                raise ValueError(f"Deck '{deck_name}' was not found in database")
+            deck_id = deck_row["id"]
+
+            cur.execute(
+                "SELECT id, name FROM sides WHERE deck_id=%s ORDER BY id",
+                (deck_id,),
+            )
+            sides = cur.fetchall()
+            side_names = {row["id"]: row["name"] for row in sides}
+
+            cur.execute(
+                "SELECT id, position FROM cards WHERE deck_id=%s ORDER BY position",
+                (deck_id,),
+            )
+            cards = cur.fetchall()
+
+            deck_cards: List[Dict[str, str]] = []
+            for card in cards:
+                card_id = card["id"]
+                cur.execute(
+                    "SELECT side_id, value FROM card_values WHERE card_id=%s",
+                    (card_id,),
+                )
+                values = {
+                    side_names[row["side_id"]]: row["value"]
+                    for row in cur.fetchall()
+                }
+
+                cur.execute(
+                    """
+                    SELECT t.name
+                    FROM card_tags ct
+                    JOIN tags t ON t.id = ct.tag_id
+                    WHERE ct.card_id=%s
+                    ORDER BY t.name
+                    """,
+                    (card_id,),
+                )
+                tags = [row["name"] for row in cur.fetchall()]
+                if tags:
+                    values["tags"] = "[" + " ".join(tags) + "]"
+                elif "tags" not in values:
+                    values["tags"] = "[]"
+
+                deck_cards.append(values)
+
+            return deck_cards
+        finally:
+            cur.close()
+            conn.close()
+
+
+def discover_csv_decks(base_dir: Path) -> List[Path]:
+    return sorted(base_dir.glob("*.csv"))
+
+
+def import_csv_deck(repo: MySQLFlashcardRepository, csv_path: Path):
+    deck_name = csv_path.stem.lower()
+    conn = repo.connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO decks (name, source_file) VALUES (%s, %s) ON DUPLICATE KEY UPDATE source_file=VALUES(source_file)",
+            (deck_name, csv_path.name),
+        )
+        cur.execute("SELECT id FROM decks WHERE name=%s", (deck_name,))
+        deck_id = cur.fetchone()[0]
+
+        cur.execute("DELETE FROM card_tags WHERE card_id IN (SELECT id FROM cards WHERE deck_id=%s)", (deck_id,))
+        cur.execute("DELETE FROM card_values WHERE card_id IN (SELECT id FROM cards WHERE deck_id=%s)", (deck_id,))
+        cur.execute("DELETE FROM sides WHERE deck_id=%s", (deck_id,))
+        cur.execute("DELETE FROM cards WHERE deck_id=%s", (deck_id,))
+
+        with csv_path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if not reader.fieldnames:
+                conn.commit()
+                return
+
+            normalized_headers = [header.lower() for header in reader.fieldnames]
+            side_headers = [h for h in normalized_headers if h != "tags"]
+            side_id_map = {}
+            for side_name in side_headers:
+                cur.execute("INSERT INTO sides (deck_id, name) VALUES (%s, %s)", (deck_id, side_name))
+                side_id_map[side_name] = cur.lastrowid
+
+            for position, row in enumerate(reader):
+                normalized = {k.lower(): (v if v is not None else "") for k, v in row.items()}
+                cur.execute(
+                    "INSERT INTO cards (deck_id, position) VALUES (%s, %s)",
+                    (deck_id, position),
+                )
+                card_id = cur.lastrowid
+
+                for side_name in side_headers:
+                    cur.execute(
+                        "INSERT INTO card_values (card_id, side_id, value) VALUES (%s, %s, %s)",
+                        (card_id, side_id_map[side_name], normalized.get(side_name, "")),
+                    )
+
+                for tag in parse_tags(normalized.get("tags", "")):
+                    cur.execute("INSERT INTO tags (name) VALUES (%s) ON DUPLICATE KEY UPDATE name=name", (tag,))
+                    cur.execute("SELECT id FROM tags WHERE name=%s", (tag,))
+                    tag_id = cur.fetchone()[0]
+                    cur.execute(
+                        "INSERT IGNORE INTO card_tags (card_id, tag_id) VALUES (%s, %s)",
+                        (card_id, tag_id),
+                    )
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+        conn.close()

--- a/flashCards.py
+++ b/flashCards.py
@@ -1,5 +1,8 @@
 import csv
 import random
+from typing import Optional
+
+from db import MySQLFlashcardRepository
 from utils import calcStrWidth
 
 
@@ -11,7 +14,7 @@ class FlashCard:
     def __str__(self):
         string = ""
         for value in self.sides.values():
-            string += ','+str(value)
+            string += ',' + str(value)
         return string[1:]
 
     def check(self, guess, side):
@@ -21,11 +24,11 @@ class FlashCard:
         value = self.sides[side]
         width = calcStrWidth(value)
         padding = 2
-        top_border = "┌" + "─" * (width + 2*padding) + "┐"
-        mid1 = "│" + " " * (width + 2*padding) + "│"
+        top_border = "┌" + "─" * (width + 2 * padding) + "┐"
+        mid1 = "│" + " " * (width + 2 * padding) + "│"
         middle_line = "│" + " " * padding + value + " " * padding + "│"
-        mid2 = "│" + " " * (width + 2*padding) + "│"
-        bottom_border = "└" + "─" * (width + 2*padding) + "┘"
+        mid2 = "│" + " " * (width + 2 * padding) + "│"
+        bottom_border = "└" + "─" * (width + 2 * padding) + "┘"
         print(top_border)
         print(mid1)
         print(middle_line)
@@ -34,9 +37,16 @@ class FlashCard:
 
 
 class FlashCardDeck:
-    def __init__(self, csvFile):
+    def __init__(self, deck_name: Optional[str] = None, repository: Optional[MySQLFlashcardRepository] = None, csvFile: Optional[str] = None):
         self.cards = []
-        self.generateCards(csvFile)
+        if deck_name and repository:
+            self.generateCardsFromDatabase(deck_name, repository)
+        elif csvFile:
+            self.generateCards(csvFile)
+        elif deck_name and deck_name.endswith(".csv"):
+            self.generateCards(deck_name)
+        else:
+            raise ValueError("FlashCardDeck requires (deck_name + repository) or csvFile")
 
     def __str__(self):
         return f"{self.cards}"
@@ -52,9 +62,15 @@ class FlashCardDeck:
             reader = csv.reader(file)
             headers = next(reader)
             for i, row in enumerate(reader):
-                sides = {header.lower(): value for header,
-                         value in zip(headers, row)}
+                sides = {header.lower(): value for header, value in zip(headers, row)}
+                if "tags" not in sides:
+                    sides["tags"] = "[]"
                 self.cards.append(FlashCard(i, **sides))
+
+    def generateCardsFromDatabase(self, deck_name, repository):
+        rows = repository.load_deck(deck_name)
+        for i, sides in enumerate(rows):
+            self.cards.append(FlashCard(i, **sides))
 
     def shuffle(self):
         random.shuffle(self.cards)

--- a/gui.py
+++ b/gui.py
@@ -2,10 +2,11 @@ import random
 import tkinter as tk
 from tkinter import ttk
 
+from db import MySQLFlashcardRepository
 from flashCards import FlashCardDeck
 
-KANA_CSV = "kana.csv"
-JAP_VOCAB_CSV = "jap-vocab.csv"
+KANA_DECK = "kana"
+JAP_VOCAB_DECK = "jap-vocab"
 
 
 class FlashcardsGUI:
@@ -14,9 +15,10 @@ class FlashcardsGUI:
         self.root.title("Kana Flashcards")
         self.root.geometry("900x420")
 
+        repository = MySQLFlashcardRepository()
         self.decks = {
-            "Kana": FlashCardDeck(KANA_CSV),
-            "Vocabulary": FlashCardDeck(JAP_VOCAB_CSV),
+            "Kana": FlashCardDeck(deck_name=KANA_DECK, repository=repository),
+            "Vocabulary": FlashCardDeck(deck_name=JAP_VOCAB_DECK, repository=repository),
         }
 
         self.deck_var = tk.StringVar(value="Kana")

--- a/main.py
+++ b/main.py
@@ -3,12 +3,12 @@
 import argparse
 import os
 
+from db import MySQLFlashcardRepository
 from flashCards import FlashCardDeck
 from gui import run_gui
 
-KANA_CSV = "kana.csv"
-KANA_TEST_CSV = "kana-test.csv"
-JAP_VOCAB_CSV = "jap-vocab.csv"
+KANA_DECK = "kana"
+JAP_VOCAB_DECK = "jap-vocab"
 
 
 def clearTerm():
@@ -81,8 +81,9 @@ def main():
     from games import customGuessCards, guessCards
     from utils import createMenu as menu
 
-    kanaCardDeck = FlashCardDeck(KANA_CSV)
-    vocabCardDeck = FlashCardDeck(JAP_VOCAB_CSV)
+    repository = MySQLFlashcardRepository()
+    kanaCardDeck = FlashCardDeck(deck_name=KANA_DECK, repository=repository)
+    vocabCardDeck = FlashCardDeck(deck_name=JAP_VOCAB_DECK, repository=repository)
     vocabTags = []
     kanaTags = []
     for card in vocabCardDeck.cards:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansiwrap==0.8.4
 console-menu==0.8.0
 six==1.17.0
 textwrap3==0.9.2
+mysql-connector-python==9.1.0

--- a/scripts/setup_mysql_db.py
+++ b/scripts/setup_mysql_db.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import mysql.connector
+
+from db import DBConfig, MySQLFlashcardRepository, discover_csv_decks, import_csv_deck, load_db_config
+
+
+def run_cmd(cmd):
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def ensure_mysql_rhel():
+    run_cmd(["sudo", "dnf", "-y", "install", "mysql-server"])
+    run_cmd(["sudo", "systemctl", "enable", "--now", "mysqld"])
+    run_cmd(["sudo", "systemctl", "is-active", "--quiet", "mysqld"])
+
+
+def ensure_database_and_user(config: DBConfig, root_user: str, root_password: str):
+    conn = mysql.connector.connect(
+        host=config.host,
+        port=config.port,
+        user=root_user,
+        password=root_password,
+        autocommit=True,
+    )
+    cur = conn.cursor()
+    try:
+        cur.execute(f"CREATE DATABASE IF NOT EXISTS `{config.database}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+        cur.execute(
+            f"CREATE USER IF NOT EXISTS '{config.user}'@'%' IDENTIFIED BY %s",
+            (config.password,),
+        )
+        cur.execute(
+            f"ALTER USER '{config.user}'@'%' IDENTIFIED BY %s",
+            (config.password,),
+        )
+        cur.execute(
+            f"GRANT ALL PRIVILEGES ON `{config.database}`.* TO '{config.user}'@'%'"
+        )
+        cur.execute("FLUSH PRIVILEGES")
+    finally:
+        cur.close()
+        conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install/setup MySQL and import flashcard CSVs")
+    parser.add_argument("--ensure-mysql", action="store_true", help="Install and start MySQL service on RHEL 8/9 using dnf")
+    parser.add_argument("--root-user", default="root", help="MySQL admin username")
+    parser.add_argument("--root-password", default="", help="MySQL admin password")
+    parser.add_argument("--csv-dir", default=".", help="Directory containing CSV files")
+    args = parser.parse_args()
+
+    if args.ensure_mysql:
+        ensure_mysql_rhel()
+
+    config = load_db_config()
+    ensure_database_and_user(config, args.root_user, args.root_password)
+
+    repo = MySQLFlashcardRepository(config)
+    repo.ensure_schema()
+
+    csv_dir = Path(args.csv_dir).resolve()
+    for csv_path in discover_csv_decks(csv_dir):
+        print(f"Importing {csv_path.name} -> deck '{csv_path.stem.lower()}'")
+        import_csv_deck(repo, csv_path)
+
+    print("MySQL setup and CSV import complete.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed: {exc}", file=sys.stderr)
+        sys.exit(exc.returncode)


### PR DESCRIPTION
### Motivation

- Replace ad-hoc CSV reads with a normalized MySQL backend so decks/cards/tags can be queried and managed more robustly. 
- Provide a one-step way to provision MySQL on RHEL 8/9 and import CSVs so updating CSVs re-syncs the authoritative DB state. 
- Ensure both the CLI and GUI consume the same DB-backed decks to remove duplicated CSV parsing logic.

### Description

- Added `db.py` implementing `DBConfig`, a normalized schema (`decks`, `cards`, `sides`, `card_values`, `tags`, `card_tags`), CSV import helpers (`discover_csv_decks`, `import_csv_deck`) and a `MySQLFlashcardRepository` wrapper with lazy `mysql.connector` import. 
- Added `scripts/setup_mysql_db.py` to optionally install MySQL on RHEL via `dnf`, enable/start `mysqld`, create the database/user/grants, apply schema, and import all `*.csv` files into normalized tables. 
- Updated `flashCards.py` so `FlashCardDeck` can load from the MySQL repository (`deck_name + repository`) while retaining CSV-based loading for local/testing (`csvFile`), and normalizing missing `tags` to `[]`. 
- Updated `main.py` and `gui.py` to instantiate `MySQLFlashcardRepository` and load decks by name (e.g. `kana`, `jap-vocab`), and updated `README.md` and `requirements.txt` (added `mysql-connector-python`) with usage and setup instructions. 

### Testing

- Ran the unit test `tests.test_flashcards` with `python -m unittest -v tests.test_flashcards` and it passed (`ok`). 
- Verified syntax by compiling modules with `python -m py_compile main.py gui.py flashCards.py db.py scripts/setup_mysql_db.py` and the compile succeeded. 
- Confirmed the test runner `python -m unittest -v` (project-wide) completes without unexpected failures in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1bd47ff38832a833ae4628923a11f)